### PR TITLE
Add attributes parsing

### DIFF
--- a/api/blueprint.go
+++ b/api/blueprint.go
@@ -31,6 +31,7 @@ type Transition struct {
 	Description  string
 	Href         Href
 	Transactions []Transaction
+	Attributes   []Attribute
 
 	Permalink string
 	Method    string
@@ -79,6 +80,11 @@ type Parameter struct {
 	Key         string
 	Value       string
 	Kind        string
+}
+
+type Attribute struct {
+	Kind       string
+	Parameters []Parameter
 }
 
 type Annotation struct {

--- a/api/blueprint.go
+++ b/api/blueprint.go
@@ -5,8 +5,11 @@ type API struct {
 	Description    string
 	Metadata       []Metadata
 	ResourceGroups []ResourceGroup
+	DataStructures DataStructures
 	Annotations    []Annotation
 }
+
+type DataStructures map[string]DataStructure
 
 type Metadata struct {
 	Key   string
@@ -17,6 +20,11 @@ type ResourceGroup struct {
 	Title       string
 	Description string
 	Resources   []*Resource
+}
+
+type DataStructure struct {
+	Name       string
+	Parameters []Parameter
 }
 
 type Resource struct {

--- a/api/parser.go
+++ b/api/parser.go
@@ -140,7 +140,7 @@ func (a *API) digDataStructures(el *Element) {
 
 	for _, child := range children {
 		data, err := child.Path("content").Children()
-		if err != nil {
+		if err != nil || len(data) == 0 {
 			continue
 		}
 

--- a/templates/alpha.html
+++ b/templates/alpha.html
@@ -194,8 +194,13 @@
                   <code>{{$transition.URL}}</code>
                 </a>
               </div>
+              {{if $transition.Attributes}}
+                {{range $attributeN, $attribute := $transition.Attributes}}
+                  {{template "BodyParameters" $attribute}}
+                {{end}}
+              {{end}}
               {{if $transition.Href.Parameters}}
-                {{template "Parameters" $transition.Href.Parameters}}
+                {{template "HrefParameters" $transition.Href.Parameters}}
               {{end}}
               {{if $transaction.Request.Headers}}
                 {{template "Headers" $transaction.Request.Headers}}
@@ -282,13 +287,29 @@
 </table>
 {{end}}
 
-{{define "Parameters"}}
+{{define "HrefParameters"}}
 <table class="ui celled definition table">
   <thead>
     <tr>
       <th colspan="4">Parameters</th>
     </tr>
   <thead>
+  {{template "Parameters" .}}
+</table>
+{{end}}
+
+{{define "BodyParameters"}}
+<table class="ui celled definition table">
+  <thead>
+    <tr>
+      <th colspan="4">Parameters ({{.Kind}})</th>
+    </tr>
+  <thead>
+  {{template "Parameters" .Parameters}}
+</table>
+{{end}}
+
+{{define "Parameters"}}
   <tbody>
   {{range $index, $param := .}}
     <tr>
@@ -304,7 +325,6 @@
     </tr>
   {{end}}
   </tbody>
-</table>
 {{end}}
 
 {{define "Divider"}}

--- a/templates/alpha.html
+++ b/templates/alpha.html
@@ -302,7 +302,7 @@
 <table class="ui celled definition table">
   <thead>
     <tr>
-      <th colspan="4">Parameters ({{.Kind}})</th>
+      <th colspan="4">Body Parameters</th>
     </tr>
   <thead>
   {{template "Parameters" .Parameters}}


### PR DESCRIPTION
Wanted to have attributes show as body parameters, instead of just the query parameters. It parses them into a list of attribute objects with parameters and displays them identically to the query parameters.

CR: @subosito 