### PR TITLE
Improve Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,8 @@ RUN cd /go/src/github.com/subosito/snowboard \
  && rm -Rf src bin pkg \
  && mkdir src bin pkg
 
-ENTRYPOINT /usr/local/bin/snowboard
+WORKDIR /docs
+VOLUME /docs
 EXPOSE 8088
+
+ENTRYPOINT ["snowboard"]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,13 @@ You can also use automated build docker image on `subosito/snowboard`:
 
 ```
 $ docker pull subosito/snowboard
-$ docker run subosito/snowboard -h
+$ docker run -it --rm subosito/snowboard -h
+```
+
+To run snowboard with the current directory mounted to /docs:
+
+```
+$ docker run -it --rm -v $PWD:/docs subosito/snowboard -i API.apib -o output.html
 ```
 
 > Note: Besides image on docker hub, you can also use image on `quay.io/subosito/snowboard`.


### PR DESCRIPTION
Hello,

This PR improve docker image:

1. exec form for entrypoint

Exec form is recommanded, to pass run command line arguments to snowboard. According to [docker documentation](https://docs.docker.com/engine/reference/builder/#/entrypoint), shell form prevents this:
> The shell form prevents any CMD or run command line arguments from being used, but has the disadvantage that your ENTRYPOINT will be started as a subcommand of /bin/sh -c, which does not pass signals.

2. Add /docs volume

This volume is useful to mount current directory, read apib file and generate documentation.
I also updated README file, to document these changes and add recommanded `-it --rm` parameters.

Have a good day,