### PR TITLE
Add a short docs to serve HTML from container

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ With this flag, You can access HTML documentation on `localhost:8088` and any up
 
 If you need to customize binding address, you can use flag `-b`.
 
+#### Serve HTML from Docker container
+
+If you want to serve HTML documentation from Docker container, don't forget to bind address and port in the contaier plus bind ports of host and container by `-p` option of Docker command.
+
+```
+$ docker run -it --rm -v $(pwd):/doc -p 8088:8088 subosito/snowboard html -i API.apib -o output.html -b 0.0.0.0:8088 -s
+```
 
 ### Generate formatted API blueprint
 


### PR DESCRIPTION
It would be nice if the docs of snowboard has a short notice to serve HTML from Docker container.
Options of Docker are very fundamental things for Docker user but some users may want to use container without any knowledge of Docker.

I referred this issue: https://github.com/subosito/snowboard/issues/21